### PR TITLE
2.1.1

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,6 +19,7 @@ platforms:
   - name: centos-6.6
     attributes:
       orchestrator:
+        configure_database: true
         package:
           version: 2.1.5-1
           url: 'https://github.com/kplimack/orchestrator-rpm/raw/master/orchestrator-2.1.5-1.x86_64.rpm'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.1.1
 * `rubygems`, `ruby-devel` and `binutils` are only needed on cent/ruby1.x
+* dont configure the database unless told to.
 
 ## 2.1.0
 * use build-essential to install gcc,make, etc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # orchestrator
 
+## 2.1.1
+* `rubygems`, `ruby-devel` and `binutils` are only needed on cent/ruby1.x
+
 ## 2.1.0
 * use build-essential to install gcc,make, etc
 * rubocop (.rubocop.yml added and files corrected)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,7 +29,7 @@ default['orchestrator']['config']['ReasonableReplicationLagSeconds'] = 10
 default['orchestrator']['config']['SlaveStartPostWaitMilliseconds'] = 1000
 default['orchestrator']['config']['UnseenInstanceForgetHours'] = 240
 default['orchestrator']['root_db_pass'] = 'snakeoil'
-default['orchestrator']['configure_database'] = false
+default['orchestrator']['configure_database'] = true
 
 # leaving this set to 'nil' will set the package install to always "upgrade" to the latest version available.
 # set this to a specific version in your wrapper-cookbook if you need a specific one.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,6 +29,7 @@ default['orchestrator']['config']['ReasonableReplicationLagSeconds'] = 10
 default['orchestrator']['config']['SlaveStartPostWaitMilliseconds'] = 1000
 default['orchestrator']['config']['UnseenInstanceForgetHours'] = 240
 default['orchestrator']['root_db_pass'] = 'snakeoil'
+default['orchestrator']['configure_database'] = false
 
 # leaving this set to 'nil' will set the package install to always "upgrade" to the latest version available.
 # set this to a specific version in your wrapper-cookbook if you need a specific one.

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description 'Installs/Configures chef-orchestrator'
 source_url 'https://github.com/silviabotros/chef-orchestrator'
 issues_url 'https://github.com/silviabotros/chef-orchestrator/issues'
 chef_version '>= 12.5.0'
-version '2.1.0'
+version '2.1.1'
 
 depends 'apt'
 depends 'build-essential'

--- a/recipes/_database_setup.rb
+++ b/recipes/_database_setup.rb
@@ -29,11 +29,18 @@ include_recipe 'build-essential'
 include_recipe 'percona::server'
 include_recipe 'percona::client'
 
+package 'ruby'
+
 package case node['platform_family']
         when 'rhel'
-          %w(ruby ruby-devel rubygems binutils)
+          unless node['languages']['ruby']['ruby_bin'] == "/usr/bin/ruby" &&
+                 node['languages']['ruby']['version'].to_i >= 2
+            %w(ruby-devel rubygems binutils)
+          else
+            []
+          end
         when 'debian'
-          %w(ruby ruby-dev libperconaserverclient18.1-dev)
+          %w(ruby-dev libperconaserverclient18.1-dev)
         end
 
 execute 'set root pass' do # ~FC037

--- a/recipes/_database_setup.rb
+++ b/recipes/_database_setup.rb
@@ -33,11 +33,11 @@ package 'ruby'
 
 package case node['platform_family']
         when 'rhel'
-          unless node['languages']['ruby']['ruby_bin'] == "/usr/bin/ruby" &&
-                 node['languages']['ruby']['version'].to_i >= 2
-            %w(ruby-devel rubygems binutils)
-          else
+          if node['languages']['ruby']['ruby_bin'] == '/usr/bin/ruby' &&
+             node['languages']['ruby']['version'].to_i >= 2
             []
+          else
+            %w(ruby-devel rubygems binutils)
           end
         when 'debian'
           %w(ruby-dev libperconaserverclient18.1-dev)

--- a/recipes/_package.rb
+++ b/recipes/_package.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-include_recipe 'orchestrator::_database_setup'
+include_recipe 'orchestrator::_database_setup' if node['orchestrator']['configure_database']
 
 local_rpm = nil
 


### PR DESCRIPTION
# orchestrator

## 2.1.1
* `rubygems`, `ruby-devel` and `binutils` are only needed on cent/ruby1.x
* only configure the database if told to.

Signed-off-by: Jake Plimack <jake.plimack@gmail.com>